### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,11 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
 	"features": {
-		"ghcr.io/devcontainers/features/node:1": {}
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/sshd:1": {                                  
+			"version": "latest"                                                     
+		}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ". .devcontainer/postCreate.sh",
+
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,4 +23,9 @@
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
+
+	// use the local settings module for the backend by default
+	"containerEnv": {
+		"DJANGO_SETTINGS_MODULE": "backend.settings.local",
+	},
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,13 @@
 
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
+			}
+		}
+	},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# install the backend dependencies
+pip3 install --user -r backend/requirements.txt
+python3 backend/manage.py migrate
+
+# install the frontend dependencies
+(cd frontend&& npm ci )

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,12 +26,13 @@
     ],
     "compounds": [
         {
-            "name": "Run Fullstack",
+            "name": "Run Full stack",
             "presentation": {
                 "hidden": false,
                 "group": "",
                 "order": 1
             },
+            "stopAll": true,
             "configurations": [
                 "Python: Django",
                 "Run npm start"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,11 @@
     "compounds": [
         {
             "name": "Run Fullstack",
+            "presentation": {
+                "hidden": false,
+                "group": "",
+                "order": 1
+            },
             "configurations": [
                 "Python: Django",
                 "Run npm start"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "npm start --prefix frontend",
+            "name": "Run npm start",
+            "request": "launch",
+            "type": "node-terminal"
+        },
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/backend/manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "justMyCode": true,
+            "env": {
+                "DJANGO_SETTINGS_MODULE": "backend.settings.local"}
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Run Fullstack",
+            "configurations": [
+                "Python: Django",
+                "Run npm start"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "options": {
+        "env": {
+            "DJANGO_SETTINGS_MODULE": "backend.settings.local",
+        }
+    },
+    "tasks": [
+        {
+            "label": "run Django migrations",
+            "type": "shell",
+            "command": "${command:python.interpreterPath}  backend/manage.py migrate",
+            "problemMatcher": [],
+        },
+        {
+            "label": "create superuser",
+            "type": "shell",
+            "command": "${command:python.interpreterPath} backend/manage.py createsuperuser",
+            "problemMatcher": [],
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Soundscape Authoring is a web app which allows users to create routed activities
 The easiest way to get started is by opening this repository in a GitHub Codespace. This will create a development environment with all the necessary tools and dependencies pre-installed.
 Click the "Open in GitHub Codespaces" button above to get started.
 
+This will start a new codespace and open VSCode in your browser. Once the codespace is ready, you can start the development server by doing the following:
+
+1. From the command palette (Ctrl+Shift+P), select "python: select interpreter" and choose python 3.12.
+2. Select "Run task" from the command palette and choose "create superuser". Fill in the details in the terminal to create a superuser.
+3. Choose the "Run and Debug" tab on the left-hand side of the screen (control+shift+D), and select "run full stack" from the dropdown menu.
+4. Click the green play button (F5) to start the server.
+5. a notification will appear in the bottom right corner of the screen with a link to open the app in a new browser window.
+
 ## Tech Stack
 
 - [Azure](https://azure.microsoft.com/)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the app will open in a new browser window. You can now start making changes to t
 
 If you want to use VSCode on your local machine, you can use the GitHub Codespaces extension to achieve the same result.
 Install the GitHub Codespaces extension from the VSCode marketplace and open this repository in a new codespace.
-See [Using Codespaces in Visual Studio Code](https://code.visualstudio.com/docs/remote/codespaces) for more information.
+See [Using Codespaces in Visual Studio Code](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code) for more information.
 For now, make sure you choose the rd-devcontainer branch when opening the codespace.
 
 Once the codespace is ready, follow the same steps as above to start the development server.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This document describes how to build and run the Soundscape Authoring web app.
 
 Soundscape Authoring is a web app which allows users to create routed activities for use with the Soundscape iOS app.
 
+## Getting Started
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/soundscape-community/authoring-tool/tree/rd-devcontainer?quickstart=1)
+
+The easiest way to get started is by opening this repository in a GitHub Codespace. This will create a development environment with all the necessary tools and dependencies pre-installed.
+Click the "Open in GitHub Codespaces" button above to get started.
+
 ## Tech Stack
 
 - [Azure](https://azure.microsoft.com/)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Soundscape Authoring is a web app which allows users to create routed activities
 
 ## Getting Started
 
+### GitHub Codespaces on the web
+
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/soundscape-community/authoring-tool/tree/rd-devcontainer?quickstart=1)
 
 The easiest way to get started is by opening this repository in a GitHub Codespace. This will create a development environment with all the necessary tools and dependencies pre-installed.
@@ -19,7 +21,18 @@ This will start a new codespace and open VSCode in your browser. Once the codesp
 2. Select "Run task" from the command palette and choose "create superuser". Fill in the details in the terminal to create a superuser.
 3. Choose the "Run and Debug" tab on the left-hand side of the screen (control+shift+D), and select "run full stack" from the dropdown menu.
 4. Click the green play button (F5) to start the server.
-5. a notification will appear in the bottom right corner of the screen with a link to open the app in a new browser window.
+5. a notification will appear in the bottom right corner of the screen with a link to open the app in a new browser window. If there are two, select the one with the port number 3000.
+
+the app will open in a new browser window. You can now start making changes to the code and see the results in real-time.
+
+### GitHub Codespaces in VSCode
+
+If you want to use VSCode on your local machine, you can use the GitHub Codespaces extension to achieve the same result.
+Install the GitHub Codespaces extension from the VSCode marketplace and open this repository in a new codespace.
+See [Using Codespaces in Visual Studio Code](https://code.visualstudio.com/docs/remote/codespaces) for more information.
+For now, make sure you choose the rd-devcontainer branch when opening the codespace.
+
+Once the codespace is ready, follow the same steps as above to start the development server.
 
 ## Tech Stack
 

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -25,7 +25,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # This value is the key to securing signed data.
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+# default to insecure secret key for local development
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'django-insecure-i45(4w6er1sabytg45#mai((%ea_36ojfr_ms3k6jin!+ikor')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/backend/backend/settings/local.py
+++ b/backend/backend/settings/local.py
@@ -24,23 +24,8 @@ ALLOWED_HOSTS = [
     'localhost', '*' # elephant: had to add star
 ]
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-    "loggers": {
-        "django.server": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-            "propagate": False,
-        },
-    },
-}
+# allow Github Code Spaces to pass CSRF origin check
+CSRF_TRUSTED_ORIGINS = [
+    'https://*.preview.app.github.dev'
+]
+

--- a/backend/backend/settings/local.py
+++ b/backend/backend/settings/local.py
@@ -28,5 +28,6 @@ ALLOWED_HOSTS = [
 CSRF_TRUSTED_ORIGINS = [
     'https://*.app.github.dev',
 'http://localhost:3000',
+'https://authoring.mur.org.uk'
 ]
 

--- a/backend/backend/settings/local.py
+++ b/backend/backend/settings/local.py
@@ -26,6 +26,7 @@ ALLOWED_HOSTS = [
 
 # allow Github Code Spaces to pass CSRF origin check
 CSRF_TRUSTED_ORIGINS = [
-    'https://*.preview.app.github.dev'
+    'https://*.app.github.dev',
+'http://localhost:3000',
 ]
 

--- a/backend/backend/settings/local.py
+++ b/backend/backend/settings/local.py
@@ -13,7 +13,6 @@ DATABASES = {
     }
 }
 
-
 # Used for serving local user-uploaded files
 # I.g., "http://127.0.0.1:8000/files/{file_path}"
 MEDIA_URL = 'files/'

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -43,7 +43,3 @@ else:
     # In a cloud environment, files are stored and served via the 'files' app.
     urlpatterns.append(path('files/', include('files.urls')))
 
-# In debug, we simulate the Azure auth by serving the auth JSON locally.
-if settings.DEBUG:
-    from .views import auth_me
-    urlpatterns.append(path('.auth/me', auth_me))

--- a/backend/files/views.py
+++ b/backend/files/views.py
@@ -12,9 +12,7 @@ from azure.storage.blob import BlobServiceClient, ContainerClient, StorageStream
 ACCOUNT_URL = "https://{}.blob.core.windows.net/".format(os.environ.get('AZURE_STORAGE_ACCOUNT_NAME'))
 CREDENTIAL = os.environ.get('AZURE_STORAGE_ACCOUNT_KEY')
 CONTAINER_NAME = os.environ.get('AZURE_STORAGE_ACCOUNT_CONTAINER')
-# elephant
-# BLOB_PATH_PREFIX = os.environ.get('AZURE_STORAGE_ACCOUNT_LOCATION') + '/'
-BLOB_PATH_PREFIX = 'asdf/'
+BLOB_PATH_PREFIX = os.getenv('AZURE_STORAGE_ACCOUNT_LOCATION', '') + '/'
 
 
 @require_http_methods(["GET"])

--- a/frontend/src/api/API.js
+++ b/frontend/src/api/API.js
@@ -57,14 +57,6 @@ function objectToFormData(object) {
 
 class API {
 
-  async authenticate() {
-    return auth.fetchAuthInfo();
-  }
-
-  async logout() {
-    auth.logout();
-  }
-
   // Activities
 
   async getActivities() {

--- a/frontend/src/components/Main/NavigationBar.jsx
+++ b/frontend/src/components/Main/NavigationBar.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Container, Dropdown, Nav, NavDropdown, Button, Navbar } from 'react-bootstrap';
 import API from '../../api/API';
+import auth from '../../api/Auth';
 import {useContext} from 'react';
 import MainContext from './MainContext';
 
@@ -47,7 +48,7 @@ export default function NavigationBar({ presentingDetail, onActivitiesShow }) {
               <Dropdown.ItemText>{user.userEmail}</Dropdown.ItemText>
               <NavDropdown.Divider />
               <NavDropdown.Item onClick={() => {
-                API.logout().then(() => {
+                auth.logout().then(() => {
                   setUser({}); 
                   window.location.reload(true);
               });

--- a/frontend/src/components/Modals/ActivityLinkModal.jsx
+++ b/frontend/src/components/Modals/ActivityLinkModal.jsx
@@ -8,9 +8,7 @@ import { Alert } from 'react-bootstrap';
 
 export default class ActivityLinkModal extends React.Component {
   render() {
-    // v2: iOS will load activity from production service
-    // v3: iOS will load activity from development service
-    const link = `https://yourservicesdomain.com/experience?id=${this.props.activity?.id}`;
+    const link = `https://share.soundscape.services/v3/experience?id=${this.props.activity?.id}`;
 
     return (
       <Modal

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,12 @@ export default defineConfig({
   server: {
     proxy: {
       '^(/admin|/api|/api-auth|/dj-rest-auth|/files|/.auth)/.*': {
-        'target': 'http://localhost:8000',
-        'xfwd': true
+        target: 'http://localhost:8000',
+        xfwd: true,
+        changeOrigin: true
       }
     },
+    host: '127.0.0.1',
     port: 3000,
   },
   build: {


### PR DESCRIPTION
- Add dev container for easier local development with VSCode
- Remove reference to the auth_me view that used to be used for local dev
- set django config module in dev container
- Enable ssh in dev container
- Fixes for Github Code Spaces
- Add tasks and launch configuration for vscode
- Reorder launch configurations
- Add python path to devcontainer.json
- add Onboarding for code spaces to README.md
- More code spaces documentation
- fix link
- Change activity url to use share.soundscape.services
- Add authoring.mur.org.uk to csrf_trusted_origins for testing
