### PR TITLE
fix proxy settings to trust https status from caddy reverse proxy

### DIFF
--- a/backend/backend/settings/production.py
+++ b/backend/backend/settings/production.py
@@ -26,6 +26,10 @@ if not any(origin.strip() for origin in CSRF_TRUSTED_ORIGINS):
 
 DEBUG = False
 
+# Trust the reverse proxy to report the original HTTPS scheme for absolute URLs
+# such as OAuth callback URIs.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',

--- a/backend/users/test_auth_flow.py
+++ b/backend/users/test_auth_flow.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 
 from allauth.account.models import EmailAddress
@@ -196,3 +196,19 @@ class CsrfBootstrapTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn('csrftoken', response.cookies)
+
+
+class ProxyHttpsTests(SimpleTestCase):
+    @override_settings(SECURE_PROXY_SSL_HEADER=('HTTP_X_FORWARDED_PROTO', 'https'))
+    def test_forwarded_https_builds_https_callback_url(self):
+        request = RequestFactory().get(
+            '/',
+            HTTP_HOST='authoring.soundscape.services',
+            HTTP_X_FORWARDED_PROTO='https',
+        )
+
+        self.assertTrue(request.is_secure())
+        self.assertEqual(
+            request.build_absolute_uri('/accounts/google/login/callback/'),
+            'https://authoring.soundscape.services/accounts/google/login/callback/',
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication callback URL handling for deployments behind reverse proxies. The system now correctly constructs HTTPS callback URLs when requests are forwarded through a reverse proxy.

* **Tests**
  * Added tests to verify authentication callbacks are properly constructed with correct protocol handling in reverse proxy environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->