### PR TITLE
Fix OSM tile referrer policy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="theme-color" content="#4D4D4D" />
     <title>Authoring Tool</title>
     <link rel="icon" href="src/media/sat_logo.ico" />

--- a/frontend/src/components/ActivitySecondary/MapView.jsx
+++ b/frontend/src/components/ActivitySecondary/MapView.jsx
@@ -30,6 +30,7 @@ const OSM_ATTR = {
   url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   attribution:
     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  referrerPolicy: 'strict-origin-when-cross-origin',
 };
 
 function shouldShowWaypointCreationControl(activity) {
@@ -352,7 +353,11 @@ export default function MapView(props) {
 
   return (
     <MapContainer bounds={bounds()} zoom={19} worldCopyJump={true} ref={mapRef} attributionControl={false}>
-      <TileLayer attribution={OSM_ATTR.attribution} url={OSM_ATTR.url} />
+      <TileLayer
+        attribution={OSM_ATTR.attribution}
+        url={OSM_ATTR.url}
+        referrerPolicy={OSM_ATTR.referrerPolicy}
+      />
       <LayersControl position="topright">
         <LayersControl.Overlay checked name="Waypoints">
           <LayerGroup>

--- a/frontend/src/components/ActivitySecondary/__tests__/MapView.test.jsx
+++ b/frontend/src/components/ActivitySecondary/__tests__/MapView.test.jsx
@@ -1,0 +1,83 @@
+// Copyright (c) Soundscape Community Contributors.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import Activity from '../../../data/Activity';
+import MapView from '../MapView';
+
+const tileLayerMock = vi.fn();
+
+vi.mock('../WaypointMarker', () => ({
+  default: () => null,
+}));
+
+vi.mock('../POIMarker', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../../utils/GPX+MapView', () => ({
+  GPXMapOverlaysBounds: vi.fn(() => [[47.64203, -122.141262]]),
+  GPXMapOverlays: vi.fn(() => null),
+}));
+
+vi.mock('react-leaflet', () => {
+  const MapContainer = React.forwardRef(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      fitBounds: vi.fn(),
+      getContainer: () => ({ style: {} }),
+    }));
+
+    return <div data-testid="map-container">{children}</div>;
+  });
+  const TileLayer = (props) => {
+    tileLayerMock(props);
+    return <div data-testid="tile-layer" />;
+  };
+  const LayersControl = ({ children }) => <div>{children}</div>;
+  LayersControl.Overlay = ({ children }) => <div>{children}</div>;
+
+  return {
+    MapContainer,
+    TileLayer,
+    Polyline: () => null,
+    useMapEvent: vi.fn(),
+    useMap: () => ({
+      fitBounds: vi.fn(),
+      getContainer: () => ({ style: {} }),
+      locate: vi.fn(),
+      setView: vi.fn(),
+      stopLocate: vi.fn(),
+    }),
+    Popup: ({ children }) => <div>{children}</div>,
+    LayersControl,
+    AttributionControl: () => null,
+    LayerGroup: ({ children }) => <div>{children}</div>,
+  };
+});
+
+describe('MapView', () => {
+  it('configures OSM tiles to send a cross-origin referrer', () => {
+    const activity = new Activity({
+      type: Activity.TYPE.GUIDED_TOUR,
+      waypoints_group: { id: 'waypoints', waypoints: [] },
+      pois_group: { id: 'pois', waypoints: [] },
+    });
+
+    render(
+      <MapView
+        activity={activity}
+        selectedWaypoint={null}
+        editing={false}
+        mapOverlay={null}
+        onWaypointCreated={() => {}}
+        onWaypointUpdated={() => {}}
+      />,
+    );
+
+    expect(tileLayerMock).toHaveBeenCalled();
+    const [tileLayerProps] = tileLayerMock.mock.calls.at(-1);
+    expect(tileLayerProps.referrerPolicy).toBe('strict-origin-when-cross-origin');
+  });
+});

--- a/frontend/src/components/ActivitySecondary/__tests__/MapView.test.jsx
+++ b/frontend/src/components/ActivitySecondary/__tests__/MapView.test.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
 
 import Activity from '../../../data/Activity';
 import MapView from '../MapView';
@@ -58,6 +58,10 @@ vi.mock('react-leaflet', () => {
 });
 
 describe('MapView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('configures OSM tiles to send a cross-origin referrer', () => {
     const activity = new Activity({
       type: Activity.TYPE.GUIDED_TOUR,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Applied a strict referrer policy to the main document and map tile loading to control referrer headers on cross-origin requests.

* **Tests**
  * Added tests to verify map tile configuration and ensure the referrer policy is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->