### PR TITLE
Add QR code copy and download actions

### DIFF
--- a/frontend/src/components/Modals/ActivityLinkModal.jsx
+++ b/frontend/src/components/Modals/ActivityLinkModal.jsx
@@ -103,7 +103,7 @@ export default class ActivityLinkModal extends React.Component {
       downloadLink.download = this.buildQrFilename();
       downloadLink.click();
 
-      URL.revokeObjectURL(objectUrl);
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
       this.setQrStatus(DOWNLOAD_SUCCESS_MESSAGE);
     } catch (error) {
       this.setQrStatus(DOWNLOAD_FAILURE_MESSAGE, 'danger');

--- a/frontend/src/components/Modals/ActivityLinkModal.jsx
+++ b/frontend/src/components/Modals/ActivityLinkModal.jsx
@@ -2,13 +2,114 @@
 // Licensed under the MIT License.
 
 import React from 'react';
+import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
-import { QRCodeSVG } from 'qrcode.react';
 import { Alert } from 'react-bootstrap';
+import { QRCodeCanvas } from 'qrcode.react';
 
 const SHARE_DOMAIN = (import.meta.env.VITE_SHARE_DOMAIN || 'https://share.soundscape.services').replace(/\/+$/, '');
+const QR_CODE_SIZE = 288;
+const COPY_UNSUPPORTED_MESSAGE = 'This browser cannot copy images to the clipboard. Use Download QR Code instead.';
+const COPY_FAILURE_MESSAGE = 'Unable to copy the QR code. Use Download QR Code instead.';
+const COPY_SUCCESS_MESSAGE = 'QR code copied to clipboard.';
+const DOWNLOAD_FAILURE_MESSAGE = 'Unable to download the QR code.';
+const DOWNLOAD_SUCCESS_MESSAGE = 'QR code download started.';
 
 export default class ActivityLinkModal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      qrStatus: null,
+      qrStatusVariant: 'success',
+    };
+
+    this.qrCodeContainerRef = React.createRef();
+  }
+
+  componentDidUpdate(prevProps) {
+    const modalChanged = prevProps.show !== this.props.show;
+    const activityChanged = prevProps.activity?.id !== this.props.activity?.id;
+
+    if ((modalChanged || activityChanged) && this.state.qrStatus !== null) {
+      this.setState({ qrStatus: null, qrStatusVariant: 'success' });
+    }
+  }
+
+  buildQrFilename() {
+    const activitySlug = (this.props.activity?.name || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    return `${activitySlug || 'activity'}-qr.png`;
+  }
+
+  getQrCanvas() {
+    return this.qrCodeContainerRef.current?.querySelector('canvas') || null;
+  }
+
+  setQrStatus(qrStatus, qrStatusVariant = 'success') {
+    this.setState({ qrStatus, qrStatusVariant });
+  }
+
+  canvasToBlob(canvas) {
+    return new Promise((resolve, reject) => {
+      if (typeof canvas?.toBlob !== 'function') {
+        reject(new Error(DOWNLOAD_FAILURE_MESSAGE));
+        return;
+      }
+
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error(DOWNLOAD_FAILURE_MESSAGE));
+          return;
+        }
+
+        resolve(blob);
+      }, 'image/png');
+    });
+  }
+
+  handleCopyQrCode = async () => {
+    const clipboard = navigator.clipboard;
+    const ClipboardItemCtor = window.ClipboardItem;
+
+    if (!clipboard?.write || !ClipboardItemCtor) {
+      this.setQrStatus(COPY_UNSUPPORTED_MESSAGE, 'warning');
+      return;
+    }
+
+    try {
+      const canvas = this.getQrCanvas();
+      const blob = await this.canvasToBlob(canvas);
+
+      await clipboard.write([new ClipboardItemCtor({ 'image/png': blob })]);
+      this.setQrStatus(COPY_SUCCESS_MESSAGE);
+    } catch (error) {
+      this.setQrStatus(COPY_FAILURE_MESSAGE, 'warning');
+    }
+  };
+
+  handleDownloadQrCode = async () => {
+    try {
+      const canvas = this.getQrCanvas();
+      const blob = await this.canvasToBlob(canvas);
+      const objectUrl = URL.createObjectURL(blob);
+      const downloadLink = document.createElement('a');
+
+      downloadLink.href = objectUrl;
+      downloadLink.download = this.buildQrFilename();
+      downloadLink.click();
+
+      URL.revokeObjectURL(objectUrl);
+      this.setQrStatus(DOWNLOAD_SUCCESS_MESSAGE);
+    } catch (error) {
+      this.setQrStatus(DOWNLOAD_FAILURE_MESSAGE, 'danger');
+    }
+  };
+
   render() {
     const activityId = this.props.activity?.id;
     const link = activityId ? `${SHARE_DOMAIN}/v3/experience?id=${activityId}` : null;
@@ -48,9 +149,29 @@ export default class ActivityLinkModal extends React.Component {
           </p>
           {link && (
             <>
-              <div className="text-center">
-                <QRCodeSVG value={link} />
+              <div className="text-center" ref={this.qrCodeContainerRef}>
+                <QRCodeCanvas
+                  value={link}
+                  size={QR_CODE_SIZE}
+                  includeMargin={true}
+                  bgColor="#FFFFFF"
+                  fgColor="#000000"
+                  aria-label="Activity QR code"
+                />
               </div>
+              <div className="d-flex justify-content-center gap-2 mt-3">
+                <Button variant="outline-secondary" onClick={this.handleCopyQrCode}>
+                  Copy QR Code
+                </Button>
+                <Button variant="outline-secondary" onClick={this.handleDownloadQrCode}>
+                  Download QR Code
+                </Button>
+              </div>
+              {this.state.qrStatus && (
+                <Alert className="mt-3 mb-0" variant={this.state.qrStatusVariant}>
+                  {this.state.qrStatus}
+                </Alert>
+              )}
               <br />
               <a href={link} target="_blank" rel="noreferrer">
                 {link}

--- a/frontend/src/components/Modals/__tests__/ActivityLinkModal.test.jsx
+++ b/frontend/src/components/Modals/__tests__/ActivityLinkModal.test.jsx
@@ -1,0 +1,183 @@
+// Copyright (c) Soundscape Community Contributors.
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ActivityLinkModal from '../ActivityLinkModal';
+
+vi.mock('react-bootstrap/Modal', () => {
+  const Modal = ({ show, children }) => (show ? <div>{children}</div> : null);
+  const ModalHeader = ({ children }) => <div>{children}</div>;
+  const ModalTitle = ({ children }) => <div>{children}</div>;
+  const ModalBody = ({ children }) => <div>{children}</div>;
+
+  Modal.displayName = 'MockModal';
+  ModalHeader.displayName = 'MockModalHeader';
+  ModalTitle.displayName = 'MockModalTitle';
+  ModalBody.displayName = 'MockModalBody';
+
+  Modal.Header = ModalHeader;
+  Modal.Title = ModalTitle;
+  Modal.Body = ModalBody;
+
+  return { default: Modal };
+});
+
+vi.mock('qrcode.react', () => ({
+  QRCodeCanvas: ({ value, size, includeMargin, bgColor, fgColor, ...props }) => (
+    <canvas data-value={value} data-size={size} {...props} />
+  ),
+}));
+
+describe('ActivityLinkModal', () => {
+  const activity = {
+    id: 'activity-123',
+    name: 'City Tour',
+    unpublished_changes: true,
+  };
+
+  let clipboardWriteMock;
+  let createObjectUrlMock;
+  let revokeObjectUrlMock;
+  let originalCreateElement;
+  let anchorClickMock;
+  let createdAnchor;
+
+  beforeEach(() => {
+    clipboardWriteMock = vi.fn(() => Promise.resolve());
+    createObjectUrlMock = vi.fn(() => 'blob:qr-code');
+    revokeObjectUrlMock = vi.fn();
+    anchorClickMock = vi.fn();
+    createdAnchor = null;
+    originalCreateElement = document.createElement.bind(document);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        write: clipboardWriteMock,
+      },
+    });
+
+    window.ClipboardItem = class ClipboardItem {
+      constructor(items) {
+        this.items = items;
+      }
+    };
+
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+      configurable: true,
+      value: vi.fn((callback) => callback(new Blob(['qr-code'], { type: 'image/png' }))),
+    });
+
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(createObjectUrlMock);
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(revokeObjectUrlMock);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      const element = originalCreateElement(tagName, options);
+
+      if (tagName === 'a') {
+        createdAnchor = element;
+        element.click = anchorClickMock;
+      }
+
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.ClipboardItem;
+  });
+
+  function renderModal(overrides = {}) {
+    render(<ActivityLinkModal show={true} activity={activity} onCancel={() => {}} {...overrides} />);
+  }
+
+  it('renders the QR actions, warning, and share link', () => {
+    renderModal();
+
+    expect(screen.getByText('Unpublished Changes Warning')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy QR Code' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download QR Code' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Activity QR code')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'https://share.soundscape.services/v3/experience?id=activity-123' }),
+    ).toBeInTheDocument();
+  });
+
+  it('copies the QR code image to the clipboard when supported', async () => {
+    const user = userEvent.setup();
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        write: clipboardWriteMock,
+      },
+    });
+
+    renderModal();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Copy QR Code' }));
+    });
+
+    await waitFor(() => expect(screen.getByText('QR code copied to clipboard.')).toBeInTheDocument());
+
+    const clipboardItems = clipboardWriteMock.mock.calls[0][0];
+    expect(clipboardWriteMock).toHaveBeenCalled();
+    expect(clipboardItems).toHaveLength(1);
+    expect(clipboardItems[0].items['image/png']).toBeInstanceOf(Blob);
+    expect(clipboardItems[0].items['image/png'].type).toBe('image/png');
+  });
+
+  it('shows a fallback message when image clipboard support is unavailable', async () => {
+    const user = userEvent.setup();
+
+    delete window.ClipboardItem;
+
+    renderModal();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Copy QR Code' }));
+    });
+
+    expect(
+      screen.getByText('This browser cannot copy images to the clipboard. Use Download QR Code instead.'),
+    ).toBeInTheDocument();
+    expect(clipboardWriteMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a fallback message when QR image export fails', async () => {
+    const user = userEvent.setup();
+    HTMLCanvasElement.prototype.toBlob = vi.fn((callback) => callback(null));
+
+    renderModal();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Copy QR Code' }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Unable to copy the QR code. Use Download QR Code instead.')).toBeInTheDocument(),
+    );
+  });
+
+  it('downloads the QR code as a PNG with an activity-based filename', async () => {
+    const user = userEvent.setup();
+
+    renderModal();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Download QR Code' }));
+    });
+
+    await waitFor(() => expect(createObjectUrlMock).toHaveBeenCalledTimes(1));
+
+    expect(createdAnchor).not.toBeNull();
+    expect(createdAnchor.download).toBe('city-tour-qr.png');
+    expect(createdAnchor.href).toBe('blob:qr-code');
+    expect(anchorClickMock).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:qr-code');
+    expect(screen.getByText('QR code download started.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Modals/__tests__/ActivityLinkModal.test.jsx
+++ b/frontend/src/components/Modals/__tests__/ActivityLinkModal.test.jsx
@@ -67,6 +67,7 @@ describe('ActivityLinkModal', () => {
 
     Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
       configurable: true,
+      writable: true,
       value: vi.fn((callback) => callback(new Blob(['qr-code'], { type: 'image/png' }))),
     });
 
@@ -177,7 +178,29 @@ describe('ActivityLinkModal', () => {
     expect(createdAnchor.download).toBe('city-tour-qr.png');
     expect(createdAnchor.href).toBe('blob:qr-code');
     expect(anchorClickMock).toHaveBeenCalledTimes(1);
-    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:qr-code');
+    await waitFor(() => expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:qr-code'));
     expect(screen.getByText('QR code download started.')).toBeInTheDocument();
+  });
+
+  it('shows a fallback message when downloading the QR code fails', async () => {
+    const user = userEvent.setup();
+    createObjectUrlMock.mockImplementationOnce(() => {
+      throw new Error('Blob URL blocked');
+    });
+
+    renderModal();
+    const anchorCountBeforeDownload = document.createElement.mock.calls.filter(([tagName]) => tagName === 'a').length;
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Download QR Code' }));
+    });
+
+    await waitFor(() => expect(screen.getByText('Unable to download the QR code.')).toBeInTheDocument());
+
+    const anchorCountAfterDownload = document.createElement.mock.calls.filter(([tagName]) => tagName === 'a').length;
+
+    expect(anchorCountAfterDownload).toBe(anchorCountBeforeDownload);
+    expect(anchorClickMock).not.toHaveBeenCalled();
+    expect(revokeObjectUrlMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- render the activity share QR code as a canvas so it can be exported as a standalone image
- add Copy QR Code and Download QR Code actions with inline fallback messaging in the link modal
- add frontend tests for QR render, copy, download, and fallback behavior

## Testing
- npm test -- --run src/components/Modals
- npx eslint src/components/Modals/ActivityLinkModal.jsx src/components/Modals/__tests__/ActivityLinkModal.test.jsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now copy activity link QR codes directly to their clipboard with feedback on success or failure.
  * Users can download QR codes as PNG image files with automatically generated filenames.

* **Tests**
  * Added comprehensive test coverage for QR code copy and download functionality, including fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->