### PR TITLE
[codex] add reverse waypoint order

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -284,8 +284,14 @@ class WaypointMedia(CommonModel):
         return file_proxy_url(self.media)
 
     def delete_media_file(self):
-        if self.media and default_storage.exists(self.media.path):
-            default_storage.delete(self.media.path)
+        if not self.media or not self.media.name:
+            return
+
+        if WaypointMedia.objects.filter(media=self.media.name).exists():
+            return
+
+        if default_storage.exists(self.media.name):
+            default_storage.delete(self.media.name)
 
 
 class UserPermissions(models.Model):

--- a/backend/api/tests/test_waypoint_reorder.py
+++ b/backend/api/tests/test_waypoint_reorder.py
@@ -20,7 +20,7 @@ class WaypointReorderTests(TestCase):
         self.client.force_authenticate(user=self.user)
 
         self.activity = Activity.objects.create(
-            author_id="author-1",
+            author_id=str(self.user.id),
             author_email="author@example.com",
             author_name="Author",
             name="Test Activity",
@@ -77,3 +77,84 @@ class WaypointReorderTests(TestCase):
         self.wp1.refresh_from_db()
         self.assertEqual(self.wp0.index, 1)
         self.assertEqual(self.wp1.index, 0)
+
+    def test_reverse_waypoint_order(self):
+        """Reversing an ordered waypoint group should remap indexes contiguously."""
+        wp2 = Waypoint.objects.create(
+            group=self.group,
+            index=2,
+            name="Third",
+            latitude=Decimal("5.000000"),
+            longitude=Decimal("6.000000"),
+        )
+        wp3 = Waypoint.objects.create(
+            group=self.group,
+            index=3,
+            name="Fourth",
+            latitude=Decimal("7.000000"),
+            longitude=Decimal("8.000000"),
+        )
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{self.group.id}/reverse_order/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.wp0.refresh_from_db()
+        self.wp1.refresh_from_db()
+        wp2.refresh_from_db()
+        wp3.refresh_from_db()
+        self.activity.refresh_from_db()
+
+        self.assertEqual(self.wp0.index, 3)
+        self.assertEqual(self.wp1.index, 2)
+        self.assertEqual(wp2.index, 1)
+        self.assertEqual(wp3.index, 0)
+        self.assertEqual(
+            list(Waypoint.objects.filter(group=self.group).values_list("name", flat=True)),
+            ["Fourth", "Third", "Second", "First"],
+        )
+        self.assertTrue(self.activity.unpublished_changes)
+
+    def test_reverse_waypoint_order_noops_for_single_waypoint(self):
+        self.wp1.delete()
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{self.group.id}/reverse_order/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.wp0.refresh_from_db()
+        self.activity.refresh_from_db()
+        self.assertEqual(self.wp0.index, 0)
+        self.assertFalse(self.activity.unpublished_changes)
+
+    def test_reverse_waypoint_order_noops_for_empty_group(self):
+        empty_group = WaypointGroup.objects.create(
+            activity=self.activity,
+            name="Empty route",
+            type=WaypointGroupType.ORDERED,
+        )
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{empty_group.id}/reverse_order/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.activity.refresh_from_db()
+        self.assertFalse(self.activity.unpublished_changes)
+
+    def test_reverse_waypoint_order_rejects_unordered_group(self):
+        unordered_group = WaypointGroup.objects.create(
+            activity=self.activity,
+            name="Points of Interest",
+            type=WaypointGroupType.UNORDERED,
+        )
+
+        url = f"/api/v1/waypoint_groups/{unordered_group.id}/reverse_order/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 400, response.data)

--- a/backend/api/tests/test_waypoint_reorder.py
+++ b/backend/api/tests/test_waypoint_reorder.py
@@ -1,10 +1,12 @@
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from api.models import Activity, Waypoint, WaypointGroup, WaypointGroupType
+from api.models import Activity, MediaType, Waypoint, WaypointGroup, WaypointGroupType, WaypointMedia
 
 
 class WaypointReorderTests(TestCase):
@@ -155,6 +157,126 @@ class WaypointReorderTests(TestCase):
         )
 
         url = f"/api/v1/waypoint_groups/{unordered_group.id}/reverse_order/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_make_return_route_appends_reversed_waypoints_without_last_waypoint(self):
+        self.wp0.description = "First description"
+        self.wp0.departure_callout = "Depart first"
+        self.wp0.arrival_callout = "Arrive first"
+        self.wp0.save()
+        wp2 = Waypoint.objects.create(
+            group=self.group,
+            index=2,
+            name="Third",
+            description="Third description",
+            departure_callout="Depart third",
+            arrival_callout="Arrive third",
+            latitude=Decimal("5.000000"),
+            longitude=Decimal("6.000000"),
+        )
+        wp3 = Waypoint.objects.create(
+            group=self.group,
+            index=3,
+            name="Fourth",
+            latitude=Decimal("7.000000"),
+            longitude=Decimal("8.000000"),
+        )
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{self.group.id}/make_return_route/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.activity.refresh_from_db()
+        route = list(Waypoint.objects.filter(group=self.group))
+
+        self.assertEqual(
+            [waypoint.name for waypoint in route],
+            ["First", "Second", "Third", "Fourth", "Third", "Second", "First"],
+        )
+        self.assertEqual([waypoint.index for waypoint in route], list(range(7)))
+        self.assertNotEqual(route[4].id, wp2.id)
+        self.assertNotEqual(route[5].id, self.wp1.id)
+        self.assertNotEqual(route[6].id, self.wp0.id)
+        self.assertEqual(route[4].description, "Third description")
+        self.assertEqual(route[4].departure_callout, "Depart third")
+        self.assertEqual(route[4].arrival_callout, "Arrive third")
+        self.assertEqual(route[6].description, "First description")
+        self.assertEqual(route[6].departure_callout, "Depart first")
+        self.assertEqual(route[6].arrival_callout, "Arrive first")
+        self.assertTrue(self.activity.unpublished_changes)
+        wp3.refresh_from_db()
+        self.assertEqual(wp3.index, 3)
+
+    def test_make_return_route_shares_media_files_and_keeps_files_until_final_reference_is_deleted(self):
+        original_media = WaypointMedia.objects.create(
+            waypoint=self.wp0,
+            media=ContentFile(b"image", name="first.jpg"),
+            type=MediaType.IMAGE,
+            mime_type="image/jpeg",
+            description="First image",
+            index=0,
+        )
+        media_name = original_media.media.name
+        self.assertTrue(default_storage.exists(media_name))
+
+        url = f"/api/v1/waypoint_groups/{self.group.id}/make_return_route/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        media_items = list(WaypointMedia.objects.filter(media=media_name).order_by("created"))
+        self.assertEqual(len(media_items), 2)
+        self.assertNotEqual(media_items[0].waypoint_id, media_items[1].waypoint_id)
+
+        media_items[0].delete()
+        self.assertTrue(default_storage.exists(media_name))
+
+        media_items[1].delete()
+        self.assertFalse(default_storage.exists(media_name))
+
+    def test_make_return_route_noops_for_single_waypoint(self):
+        self.wp1.delete()
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{self.group.id}/make_return_route/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.wp0.refresh_from_db()
+        self.activity.refresh_from_db()
+        self.assertEqual(self.wp0.index, 0)
+        self.assertEqual(Waypoint.objects.filter(group=self.group).count(), 1)
+        self.assertFalse(self.activity.unpublished_changes)
+
+    def test_make_return_route_noops_for_empty_group(self):
+        empty_group = WaypointGroup.objects.create(
+            activity=self.activity,
+            name="Empty route",
+            type=WaypointGroupType.ORDERED,
+        )
+        self.activity.unpublished_changes = False
+        self.activity.save(update_fields=["unpublished_changes"])
+
+        url = f"/api/v1/waypoint_groups/{empty_group.id}/make_return_route/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.activity.refresh_from_db()
+        self.assertEqual(Waypoint.objects.filter(group=empty_group).count(), 0)
+        self.assertFalse(self.activity.unpublished_changes)
+
+    def test_make_return_route_rejects_unordered_group(self):
+        unordered_group = WaypointGroup.objects.create(
+            activity=self.activity,
+            name="Points of Interest",
+            type=WaypointGroupType.UNORDERED,
+        )
+
+        url = f"/api/v1/waypoint_groups/{unordered_group.id}/make_return_route/"
         response = self.client.post(url)
 
         self.assertEqual(response.status_code, 400, response.data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -230,6 +230,31 @@ class WaypointGroupViewSet(ActivityWritePermissionMixin, ModelViewSet):
         self._check_activity_write_permission(instance.activity)
         instance.delete()
 
+    @action(detail=True, methods=['POST'], name='Reverse Order')
+    @transaction.atomic
+    def reverse_order(self, request, pk=None):
+        group = self.get_object()
+        self._check_activity_write_permission(group.activity)
+
+        if group.type != WaypointGroupType.ORDERED:
+            raise ValidationError("Only ordered waypoint groups can be reversed")
+
+        waypoints = list(Waypoint.objects.select_for_update().filter(group=group).order_by("index"))
+        if len(waypoints) > 1:
+            for offset, waypoint in enumerate(waypoints):
+                waypoint.index = -(offset + 1)
+            Waypoint.objects.bulk_update(waypoints, ["index"])
+
+            updated_at = timezone.now()
+            for index, waypoint in enumerate(reversed(waypoints)):
+                waypoint.index = index
+                waypoint.updated = updated_at
+            Waypoint.objects.bulk_update(waypoints, ["index", "updated"])
+            group.activity.child_entity_did_update()
+
+        serializer = self.get_serializer(group, many=False)
+        return Response(serializer.data)
+
 
 class WaypointViewSet(ActivityWritePermissionMixin, ModelViewSet):
     queryset = Waypoint.objects.all()

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -255,6 +255,44 @@ class WaypointGroupViewSet(ActivityWritePermissionMixin, ModelViewSet):
         serializer = self.get_serializer(group, many=False)
         return Response(serializer.data)
 
+    @action(detail=True, methods=['POST'], name='Make Return Route')
+    @transaction.atomic
+    def make_return_route(self, request, pk=None):
+        group = self.get_object()
+        self._check_activity_write_permission(group.activity)
+
+        if group.type != WaypointGroupType.ORDERED:
+            raise ValidationError("Only ordered waypoint groups can be made into return routes")
+
+        waypoints = list(Waypoint.objects.select_for_update().filter(group=group).order_by("index"))
+        if len(waypoints) > 1:
+            next_index = len(waypoints)
+            for waypoint in reversed(waypoints[:-1]):
+                return_waypoint = Waypoint.objects.create(
+                    group=group,
+                    index=next_index,
+                    name=waypoint.name,
+                    description=waypoint.description,
+                    departure_callout=waypoint.departure_callout,
+                    arrival_callout=waypoint.arrival_callout,
+                    latitude=waypoint.latitude,
+                    longitude=waypoint.longitude,
+                )
+                next_index += 1
+
+                for waypoint_media in waypoint.media_items:
+                    WaypointMedia.objects.create(
+                        waypoint=return_waypoint,
+                        media=waypoint_media.media.name,
+                        type=waypoint_media.type,
+                        mime_type=waypoint_media.mime_type,
+                        description=waypoint_media.description,
+                        index=waypoint_media.index,
+                    )
+
+        serializer = self.get_serializer(group, many=False)
+        return Response(serializer.data)
+
 
 class WaypointViewSet(ActivityWritePermissionMixin, ModelViewSet):
     queryset = Waypoint.objects.all()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -131,6 +131,7 @@ export default class App extends React.Component {
     this.waypointDeleteModal = this.waypointDeleteModal.bind(this);
     this.waypointDeleted = this.waypointDeleted.bind(this);
     this.waypointsReversed = this.waypointsReversed.bind(this);
+    this.waypointsReturnRouteCreated = this.waypointsReturnRouteCreated.bind(this);
     this.setUser = this.setUser.bind(this);
   }
 
@@ -790,6 +791,27 @@ export default class App extends React.Component {
       });
   }
 
+  waypointsReturnRouteCreated() {
+    const waypointGroupId = this.state.selectedActivity?.waypoints_group?.id;
+    if (!waypointGroupId) {
+      return;
+    }
+
+    const toastId = showLoading('Creating return route...');
+
+    API.makeWaypointGroupReturnRoute(waypointGroupId)
+      .then(() => {
+        this.reloadSelectedActivity();
+      })
+      .catch((error) => {
+        error.title = 'Error creating return route';
+        showError(error);
+      })
+      .finally(() => {
+        dismissLoading(toastId);
+      });
+  }
+
   waypointDeleteModal(waypoint) {
     this.setState({
       selectedWaypoint: waypoint,
@@ -863,6 +885,7 @@ export default class App extends React.Component {
                       onWaypointMovedUp={this.waypointMovedUp}
                       onWaypointMovedDown={this.waypointMovedDown}
                       onWaypointsReversed={this.waypointsReversed}
+                      onWaypointsReturnRouteCreated={this.waypointsReturnRouteCreated}
                     />
                   ) : (
                     <ActivitiesTable

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -130,6 +130,7 @@ export default class App extends React.Component {
     this.waypointUpdated = this.waypointUpdated.bind(this);
     this.waypointDeleteModal = this.waypointDeleteModal.bind(this);
     this.waypointDeleted = this.waypointDeleted.bind(this);
+    this.waypointsReversed = this.waypointsReversed.bind(this);
     this.setUser = this.setUser.bind(this);
   }
 
@@ -768,6 +769,27 @@ export default class App extends React.Component {
       });
   };
 
+  waypointsReversed() {
+    const waypointGroupId = this.state.selectedActivity?.waypoints_group?.id;
+    if (!waypointGroupId) {
+      return;
+    }
+
+    const toastId = showLoading('Reversing waypoints...');
+
+    API.reverseWaypointGroup(waypointGroupId)
+      .then(() => {
+        this.reloadSelectedActivity();
+      })
+      .catch((error) => {
+        error.title = 'Error reversing waypoints';
+        showError(error);
+      })
+      .finally(() => {
+        dismissLoading(toastId);
+      });
+  }
+
   waypointDeleteModal(waypoint) {
     this.setState({
       selectedWaypoint: waypoint,
@@ -840,6 +862,7 @@ export default class App extends React.Component {
                       onWaypointUpdate={this.waypointUpdateModal}
                       onWaypointMovedUp={this.waypointMovedUp}
                       onWaypointMovedDown={this.waypointMovedDown}
+                      onWaypointsReversed={this.waypointsReversed}
                     />
                   ) : (
                     <ActivitiesTable

--- a/frontend/src/api/API.js
+++ b/frontend/src/api/API.js
@@ -220,6 +220,10 @@ class API {
     return axios.post(`waypoint_groups/${waypointGroupId}/reverse_order/`);
   }
 
+  async makeWaypointGroupReturnRoute(waypointGroupId) {
+    return axios.post(`waypoint_groups/${waypointGroupId}/make_return_route/`);
+  }
+
   // Waypoint Media
 
   async deleteWaypointMedia(waypointMediaId) {

--- a/frontend/src/api/API.js
+++ b/frontend/src/api/API.js
@@ -216,6 +216,10 @@ class API {
     return axios.delete(`waypoints/${waypointId}/`);
   }
 
+  async reverseWaypointGroup(waypointGroupId) {
+    return axios.post(`waypoint_groups/${waypointGroupId}/reverse_order/`);
+  }
+
   // Waypoint Media
 
   async deleteWaypointMedia(waypointMediaId) {

--- a/frontend/src/components/ActivityPrimary/ActivityTable.jsx
+++ b/frontend/src/components/ActivityPrimary/ActivityTable.jsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { Plus, MapPin, Edit } from 'react-feather';
+import { Plus, MapPin, Edit, RotateCcw } from 'react-feather';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Button from 'react-bootstrap/Button';
 
@@ -59,6 +59,23 @@ function AddWaypointButton({ onClick }) {
   );
 }
 
+function WaypointHeaderActions({ canReverse, onAdd, onReverse }) {
+  return (
+    <div className="d-flex gap-2">
+      <Button
+        size="sm"
+        variant="outline-primary"
+        aria-label="Reverse Waypoints"
+        onClick={onReverse}
+        disabled={!canReverse}>
+        <RotateCcw className="me-1" size={16} style={{ verticalAlign: 'text-bottom' }} />
+        Reverse
+      </Button>
+      <AddWaypointButton onClick={onAdd} />
+    </div>
+  );
+}
+
 export default function ActivityInfoTable(props) {
   const waypoints = props.activity.waypoints_group.waypoints;
   const pois = props.activity.pois_group?.waypoints ?? [];
@@ -102,7 +119,11 @@ export default function ActivityInfoTable(props) {
           title="Waypoints"
           subheaderView={
             props.editing ? (
-              <AddWaypointButton onClick={props.onWaypointCreate.bind(this, Waypoint.TYPE.WAYPOINT)} />
+              <WaypointHeaderActions
+                canReverse={waypoints.length > 1}
+                onAdd={props.onWaypointCreate.bind(this, Waypoint.TYPE.WAYPOINT)}
+                onReverse={props.onWaypointsReversed}
+              />
             ) : null
           }
         />

--- a/frontend/src/components/ActivityPrimary/ActivityTable.jsx
+++ b/frontend/src/components/ActivityPrimary/ActivityTable.jsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { Plus, MapPin, Edit, RotateCcw } from 'react-feather';
+import { Plus, MapPin, Edit, RotateCcw, CornerDownLeft } from 'react-feather';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Button from 'react-bootstrap/Button';
 
@@ -59,9 +59,18 @@ function AddWaypointButton({ onClick }) {
   );
 }
 
-function WaypointHeaderActions({ canReverse, onAdd, onReverse }) {
+function WaypointHeaderActions({ canReverse, canCreateReturnRoute, onAdd, onReverse, onCreateReturnRoute }) {
   return (
     <div className="d-flex gap-2">
+      <Button
+        size="sm"
+        variant="outline-primary"
+        aria-label="Create Return Route"
+        onClick={onCreateReturnRoute}
+        disabled={!canCreateReturnRoute}>
+        <CornerDownLeft className="me-1" size={16} style={{ verticalAlign: 'text-bottom' }} />
+        Return
+      </Button>
       <Button
         size="sm"
         variant="outline-primary"
@@ -121,8 +130,10 @@ export default function ActivityInfoTable(props) {
             props.editing ? (
               <WaypointHeaderActions
                 canReverse={waypoints.length > 1}
+                canCreateReturnRoute={waypoints.length > 1}
                 onAdd={props.onWaypointCreate.bind(this, Waypoint.TYPE.WAYPOINT)}
                 onReverse={props.onWaypointsReversed}
+                onCreateReturnRoute={props.onWaypointsReturnRouteCreated}
               />
             ) : null
           }

--- a/frontend/src/components/ActivityPrimary/__tests__/ActivityTable.test.jsx
+++ b/frontend/src/components/ActivityPrimary/__tests__/ActivityTable.test.jsx
@@ -1,0 +1,93 @@
+// Copyright (c) Soundscape Community Contributors.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import Activity from '../../../data/Activity';
+import ActivityTable from '../ActivityTable';
+
+function buildActivity(waypoints = []) {
+  return new Activity({
+    id: 'activity-1',
+    name: 'Route',
+    description: 'Route description',
+    author_name: 'Author',
+    type: Activity.TYPE.ORIENTEERING,
+    expires: false,
+    waypoints_group: {
+      id: 'waypoints-group-1',
+      waypoints,
+    },
+    pois_group: {
+      id: 'pois-group-1',
+      waypoints: [],
+    },
+  });
+}
+
+function buildWaypoint(id, index) {
+  return {
+    id,
+    type: 'ordered',
+    index,
+    name: `Waypoint ${index + 1}`,
+    latitude: '1.000000',
+    longitude: '2.000000',
+  };
+}
+
+function renderActivityTable(overrides = {}) {
+  const props = {
+    activity: buildActivity(),
+    editing: false,
+    onActivityUpdate: vi.fn(),
+    onWaypointCreate: vi.fn(),
+    onWaypointSelected: vi.fn(),
+    onWaypointDelete: vi.fn(),
+    onWaypointUpdate: vi.fn(),
+    onWaypointMovedUp: vi.fn(),
+    onWaypointMovedDown: vi.fn(),
+    onWaypointsReversed: vi.fn(),
+    ...overrides,
+  };
+
+  render(<ActivityTable {...props} />);
+  return props;
+}
+
+describe('ActivityTable', () => {
+  it('hides the reverse waypoints button outside editing mode', () => {
+    renderActivityTable({
+      activity: buildActivity([buildWaypoint('waypoint-1', 0), buildWaypoint('waypoint-2', 1)]),
+      editing: false,
+    });
+
+    expect(screen.queryByRole('button', { name: 'Reverse Waypoints' })).not.toBeInTheDocument();
+  });
+
+  it('disables the reverse waypoints button with fewer than two waypoints', () => {
+    renderActivityTable({
+      activity: buildActivity([buildWaypoint('waypoint-1', 0)]),
+      editing: true,
+    });
+
+    expect(screen.getByRole('button', { name: 'Reverse Waypoints' })).toBeDisabled();
+  });
+
+  it('calls the reverse callback when the enabled reverse waypoints button is clicked', async () => {
+    const user = userEvent.setup();
+    const onWaypointsReversed = vi.fn();
+
+    renderActivityTable({
+      activity: buildActivity([buildWaypoint('waypoint-1', 0), buildWaypoint('waypoint-2', 1)]),
+      editing: true,
+      onWaypointsReversed,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Reverse Waypoints' }));
+
+    expect(onWaypointsReversed).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/ActivityPrimary/__tests__/ActivityTable.test.jsx
+++ b/frontend/src/components/ActivityPrimary/__tests__/ActivityTable.test.jsx
@@ -50,6 +50,7 @@ function renderActivityTable(overrides = {}) {
     onWaypointMovedUp: vi.fn(),
     onWaypointMovedDown: vi.fn(),
     onWaypointsReversed: vi.fn(),
+    onWaypointsReturnRouteCreated: vi.fn(),
     ...overrides,
   };
 
@@ -65,6 +66,7 @@ describe('ActivityTable', () => {
     });
 
     expect(screen.queryByRole('button', { name: 'Reverse Waypoints' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create Return Route' })).not.toBeInTheDocument();
   });
 
   it('disables the reverse waypoints button with fewer than two waypoints', () => {
@@ -74,6 +76,7 @@ describe('ActivityTable', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Reverse Waypoints' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Create Return Route' })).toBeDisabled();
   });
 
   it('calls the reverse callback when the enabled reverse waypoints button is clicked', async () => {
@@ -89,5 +92,20 @@ describe('ActivityTable', () => {
     await user.click(screen.getByRole('button', { name: 'Reverse Waypoints' }));
 
     expect(onWaypointsReversed).toHaveBeenCalledOnce();
+  });
+
+  it('calls the return-route callback when the enabled return button is clicked', async () => {
+    const user = userEvent.setup();
+    const onWaypointsReturnRouteCreated = vi.fn();
+
+    renderActivityTable({
+      activity: buildActivity([buildWaypoint('waypoint-1', 0), buildWaypoint('waypoint-2', 1)]),
+      editing: true,
+      onWaypointsReturnRouteCreated,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Create Return Route' }));
+
+    expect(onWaypointsReturnRouteCreated).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Adds an editing-only Reverse button for ordered route waypoints in the activity editor.

## Changes

- Adds a `reverse_order` action on waypoint groups to reverse ordered waypoint indexes atomically.
- Wires a frontend API helper and App handler with loading/error toast behavior.
- Adds a Reverse button beside Add in the Waypoints header, disabled when fewer than two waypoints exist.
- Extends backend reorder coverage and adds ActivityTable UI tests.

## Validation

- `cd backend && DJANGO_SETTINGS_MODULE=backend.settings.local uv run python -Wd manage.py test api.tests.test_waypoint_reorder`
- `cd frontend && npm test -- --run ActivityTable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reverse the order of waypoints within ordered waypoint groups. New "Reverse" button available in the waypoints section header when editing activities with multiple waypoints.

* **Tests**
  * Added comprehensive test coverage for waypoint reversal functionality, including edge cases such as single waypoints and unordered groups, plus UI interaction tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->