### PR TITLE
[codex] fix stale waypoint marker metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This is a Django + React web application for creating routed activities (GPS-bas
 ### Frontend Build Process
 - Frontend builds to `backend/frontend/serve/` via Vite config
 - Development: `npm run start` (port 3000) proxies API calls to Django (port 8000) - no build needed
+- For local browser/manual testing, use `http://localhost:3000` (not `http://127.0.0.1:3000`)
 - Production: `npm run build` then Django serves static files via WhiteNoise
 
 ### Critical Startup Sequence

--- a/frontend/src/components/ActivitySecondary/MapView.jsx
+++ b/frontend/src/components/ActivitySecondary/MapView.jsx
@@ -212,7 +212,7 @@ export default function MapView(props) {
 
     return waypoints.map((waypoint) => (
       <WaypointMarker
-        key={waypoint.id}
+        key={`${waypoint.id}:${waypoint.index}:${waypoint.name}`}
         waypoint={waypoint}
         editing={props.editing}
         onWaypointMove={onWaypointMove}
@@ -250,7 +250,7 @@ export default function MapView(props) {
 
     return waypoints.map((waypoint) => (
       <POIMarker
-        key={waypoint.id}
+        key={`${waypoint.id}:${waypoint.name}`}
         waypoint={waypoint}
         editing={props.editing}
         onWaypointMove={onWaypointMove}

--- a/frontend/src/components/ActivitySecondary/POIMarker.jsx
+++ b/frontend/src/components/ActivitySecondary/POIMarker.jsx
@@ -22,14 +22,9 @@ export default function POIMarker({ waypoint, editing, onWaypointMove }) {
       title={title}
       icon={mapPinIcon}
       draggable={editing}
-      waypoint={waypoint}
       eventHandlers={{
         dragend: (event) => {
-          // We pass the waypoint ID and not the object itself because for some reason
-          // it is passing the object the map loaded the first time.
-          // If the waypoint was edited, such as a change in name, it will still
-          // return the original object.
-          onWaypointMove(event.target.options.waypoint.id, event.target._latlng);
+          onWaypointMove(waypoint.id, event.target._latlng);
         },
       }}>
       <Popup>

--- a/frontend/src/components/ActivitySecondary/WaypointMarker.jsx
+++ b/frontend/src/components/ActivitySecondary/WaypointMarker.jsx
@@ -21,14 +21,9 @@ export default function WaypointMarker({ waypoint, editing, onWaypointMove }) {
       title={title}
       icon={mapPinIcon}
       draggable={editing}
-      waypoint={waypoint}
       eventHandlers={{
         dragend: (event) => {
-          // We pass the waypoint ID and not the object itself because for some reason
-          // it is passing the object the map loaded the first time.
-          // If the waypoint was edited, such as a change in name, it will still
-          // return the original object.
-          onWaypointMove(event.target.options.waypoint.id, event.target._latlng);
+          onWaypointMove(waypoint.id, event.target._latlng);
         },
       }}>
       <Tooltip permanent>{`${waypoint.index + 1}`}</Tooltip>

--- a/frontend/src/components/ActivitySecondary/__tests__/MapViewMarkerMetadata.test.jsx
+++ b/frontend/src/components/ActivitySecondary/__tests__/MapViewMarkerMetadata.test.jsx
@@ -1,0 +1,144 @@
+// Copyright (c) Soundscape Community Contributors.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Activity from '../../../data/Activity';
+import MapView from '../MapView';
+
+vi.mock('../../../utils/GPX+MapView', () => ({
+  GPXMapOverlaysBounds: vi.fn(() => [[47.64203, -122.141262]]),
+  GPXMapOverlays: vi.fn(() => null),
+}));
+
+vi.mock('react-leaflet', () => {
+  const MapContainer = React.forwardRef(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      fitBounds: vi.fn(),
+      getContainer: () => ({ style: {} }),
+    }));
+
+    return <div data-testid="map-container">{children}</div>;
+  });
+
+  const Marker = ({ children, title }) => {
+    // Leaflet marker options are immutable after mount, so this mock keeps the
+    // original title until React remounts the Marker.
+    const [mountedTitle] = React.useState(title);
+    return (
+      <div data-testid="leaflet-marker" title={mountedTitle}>
+        {children}
+      </div>
+    );
+  };
+
+  const LayersControl = ({ children }) => <div>{children}</div>;
+  LayersControl.Overlay = ({ children }) => <div>{children}</div>;
+
+  return {
+    MapContainer,
+    Marker,
+    TileLayer: () => null,
+    Polyline: ({ children }) => <div>{children}</div>,
+    Tooltip: ({ children, permanent }) => (
+      <span data-testid={permanent ? 'waypoint-tooltip' : undefined}>{children}</span>
+    ),
+    Popup: ({ children }) => <div>{children}</div>,
+    useMapEvent: vi.fn(),
+    useMap: () => ({
+      fitBounds: vi.fn(),
+      getContainer: () => ({ style: {} }),
+      locate: vi.fn(),
+      setView: vi.fn(),
+      stopLocate: vi.fn(),
+    }),
+    LayersControl,
+    AttributionControl: () => null,
+    LayerGroup: ({ children }) => <div>{children}</div>,
+  };
+});
+
+function buildActivity({ waypoint, poi } = {}) {
+  return new Activity({
+    type: Activity.TYPE.ORIENTEERING,
+    waypoints_group: {
+      id: 'waypoints',
+      waypoints: waypoint ? [waypoint] : [],
+    },
+    pois_group: {
+      id: 'pois',
+      waypoints: poi ? [poi] : [],
+    },
+  });
+}
+
+function buildWaypoint(overrides = {}) {
+  return {
+    id: 'waypoint-1',
+    type: 'ordered',
+    index: 0,
+    name: 'point1',
+    latitude: '47.642030',
+    longitude: '-122.141262',
+    ...overrides,
+  };
+}
+
+function renderMap(activity) {
+  return render(
+    <MapView
+      activity={activity}
+      selectedWaypoint={null}
+      editing={false}
+      mapOverlay={null}
+      onWaypointCreated={() => {}}
+      onWaypointUpdated={() => {}}
+    />,
+  );
+}
+
+describe('MapView marker metadata', () => {
+  it('refreshes ordered marker metadata when an existing waypoint is reordered or renamed', () => {
+    const { rerender } = renderMap(buildActivity({ waypoint: buildWaypoint() }));
+
+    expect(screen.getByTestId('waypoint-tooltip')).toHaveTextContent('1');
+    expect(screen.getByText('1. point1')).toBeInTheDocument();
+    expect(screen.getByTestId('leaflet-marker')).toHaveAttribute('title', '1. point1');
+
+    rerender(
+      <MapView
+        activity={buildActivity({ waypoint: buildWaypoint({ index: 1, name: 'point2' }) })}
+        selectedWaypoint={null}
+        editing={false}
+        mapOverlay={null}
+        onWaypointCreated={() => {}}
+        onWaypointUpdated={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('waypoint-tooltip')).toHaveTextContent('2');
+    expect(screen.getByText('2. point2')).toBeInTheDocument();
+    expect(screen.getByTestId('leaflet-marker')).toHaveAttribute('title', '2. point2');
+  });
+
+  it('refreshes POI marker titles when an existing POI is renamed', () => {
+    const poi = buildWaypoint({ id: 'poi-1', type: 'unordered', name: 'Museum' });
+    const { rerender } = renderMap(buildActivity({ poi }));
+
+    expect(screen.getByTestId('leaflet-marker')).toHaveAttribute('title', 'Museum');
+
+    rerender(
+      <MapView
+        activity={buildActivity({ poi: buildWaypoint({ id: 'poi-1', type: 'unordered', name: 'Gallery' }) })}
+        selectedWaypoint={null}
+        editing={false}
+        mapOverlay={null}
+        onWaypointCreated={() => {}}
+        onWaypointUpdated={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('leaflet-marker')).toHaveAttribute('title', 'Gallery');
+  });
+});


### PR DESCRIPTION
## Summary
- remount ordered waypoint markers when their displayed index or name changes
- avoid storing stale waypoint objects inside Leaflet marker options during drag handling
- refresh POI marker titles after rename and add regression coverage for marker metadata rerenders

## Why
`react-leaflet` preserves the same underlying Leaflet marker instance when the React key is stable. Leaflet marker options such as `title` are effectively fixed after mount, so reordering a waypoint could update the sidebar and popup content while leaving the native marker title stale.

## Impact
Waypoint marker metadata now stays aligned with the current activity state after reorder or rename, without requiring a page refresh. POI titles receive the same protection on rename.

## Validation
- `cd frontend && npm test -- --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage to ensure map marker labels and tooltips refresh when waypoint/POI names or order change.

* **Bug Fix**
  * Map markers now reliably update their displayed titles/tooltips and reflect edits or reordering.

* **Refactor**
  * Improved marker event handling for more consistent drag/update behavior.

* **Documentation**
  * Clarified local browser testing URL to use http://localhost:3000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->